### PR TITLE
Exchange build-dist.sh shell script for a pyproject-based task executor.

### DIFF
--- a/build-dist.sh
+++ b/build-dist.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-poetry run pyinstaller --workpath .build --specpath dist -n codelimit -F codelimit/__main__.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -744,6 +744,17 @@ files = [
 ]
 
 [[package]]
+name = "pastel"
+version = "0.2.1"
+description = "Bring colors to your terminal."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
+    {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
+]
+
+[[package]]
 name = "pefile"
 version = "2023.2.7"
 description = "Python PE parsing module"
@@ -784,6 +795,24 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "poethepoet"
+version = "0.21.1"
+description = "A task runner that works well with poetry."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "poethepoet-0.21.1-py3-none-any.whl", hash = "sha256:c79b2aefc889c4490db9d64ecc1896db78700aa212b8c5f0bca4aee0395e7714"},
+    {file = "poethepoet-0.21.1.tar.gz", hash = "sha256:39d754f53714545a23cfc94b122deaf3548218b6e35b453c30973c5598719e9f"},
+]
+
+[package.dependencies]
+pastel = ">=0.2.1,<0.3.0"
+tomli = ">=1.2.2"
+
+[package.extras]
+poetry-plugin = ["poetry (>=1.0,<2.0)"]
 
 [[package]]
 name = "pygments"
@@ -1173,4 +1202,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "918b7d9253977afbc7632834641385af46a00f7d3a4e25b1139cf68b5f4fbd06"
+content-hash = "bd632bca5740fecaff4526c4df7cb81b04875989645fb6e96903316d9bbf97eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ textual = {extras = ["dev"], version = "^0.10.1"}
 requests = "^2.28.2"
 typer = "^0.9.0"
 
+[tool.poe.tasks.bundle]
+help = "Create a binary executable using pyinstaller"
+cmd = "poetry run pyinstaller --workpath .build --specpath dist -n codelimit -F codelimit/__main__.py"
+
 [tool.semantic_release]
 version_variable = "codelimit/version.py:version"
 branch = "main"
@@ -28,6 +32,7 @@ build_command = "poetry build"
 pyinstaller = "^5.6.1"
 pytest-cov = "^4.0.0"
 pytest = "^7.2.1"
+poethepoet = "^0.21.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ typer = "^0.9.0"
 
 [tool.poe.tasks.bundle]
 help = "Create a binary executable using pyinstaller"
-cmd = "poetry run pyinstaller --workpath .build --specpath dist -n codelimit -F codelimit/__main__.py"
+cmd = "pyinstaller --workpath .build --specpath dist -n codelimit -F codelimit/__main__.py"
 
 [tool.semantic_release]
 version_variable = "codelimit/version.py:version"


### PR DESCRIPTION
I've found [`poethepoet`][poe] to be a great replacement for Makefiles or shell scripts in python projects. The first advantage is the rules are included in the pyproject.toml file instead of an ancillary file (fewer things to keep track of). The second is poe is very versatile, being able to run python code directly in addition to commands like a shell script. Thirdly the task runner is a dependency that poetry knows how to install.  No more depending on make or a suitable shell script that may or may not be available in the build environment (like actions or VMs). With this commit, I've added poethepoet as a development dependency and and replaced the build-dist.sh script with a poe task called "bundle" that replicates the functionality of the script exactly.

Some cool things:
```console
$ poetry run poe
Poe the Poet - A task runner that works well with poetry.
version 0.21.1

Result: No task specified.

USAGE
  poe [-h] [-v | -q] [--root PATH] [--ansi | --no-ansi] task [task arguments]

GLOBAL OPTIONS
  -h, --help     Show this help page and exit
  --version      Print the version and exit
  -v, --verbose  Increase command output (repeatable)
  -q, --quiet    Decrease command output (repeatable)
  -d, --dry-run  Print the task contents but don't actually run it
  --root PATH    Specify where to find the pyproject.toml
  --ansi         Force enable ANSI output
  --no-ansi      Force disable ANSI output

CONFIGURED TASKS
  bundle         Create a binary executable using pyinstaller
```

After the usage noise, the important part is the "CONFIGURED TASKS" section, which shows the task name and a brief explanation of the task. 

To invoke the task:
```console
$ poetry run poe bundle
<bundling noises>
$
```

[poe]: https://poethepoet.natn.io/index.html